### PR TITLE
Allow specification of a local fasta file instead of ucsc download

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     packages=[''],
     url='',
     license='',
-    install_requires=[ 'numpy', 'biopython', 'requests'],
+    install_requires=[ 'numpy', 'biopython', 'requests', 'pysam'],
     author='Keith Simmon',
     author_email='keith.simmon@aruplab.com',
     description='returns kmer counts for sequence regions'


### PR DESCRIPTION
Use -r / --reference on command line to use a local fasta file for querying sequence. This adds a dependency on pysam, which maybe isn't so great...but querying fasta files is fast & easy this way. Previous behavior is still supported: if -r is omitted sequence will be downloaded from UCSC as needed 